### PR TITLE
fix compile error and runtime error in ros-noetic

### DIFF
--- a/include/viewer.h
+++ b/include/viewer.h
@@ -4,6 +4,7 @@
 
 #include <image_transport/image_transport.h>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc_c.h>
 #include <ros/ros.h>
 
 #include "patch.h"

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -82,6 +82,7 @@ bool Optimizer::precomputeLogImageArray(const tracker::Patches& patches, const t
     // store this for later use
     const ros::Time& t = image_it->first;
     optimizer_data_[t] = OptimizerDatum(grad, image_it->second, patches.size());
+    return true;
 }
 
 void Optimizer::optimizeParameters(const cv::Mat &event_frame, tracker::Patch &patch)


### PR DESCRIPTION
The missing header file <imgproc_c.h> will cause compile error and  the missing return statement in Optimizer::precomputeLogImageArray will cause segment fault. The current pr version fixes them already. 